### PR TITLE
add InjectorStandalone app

### DIFF
--- a/InjectorStandalone/App.config
+++ b/InjectorStandalone/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/InjectorStandalone/InjectorStandalone.cs
+++ b/InjectorStandalone/InjectorStandalone.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace InjectorStandalone
+{
+    class InjectorStandalone
+    {
+        static void Main(string[] args)
+        {
+            if (args.Length < 2)
+            {
+                Console.WriteLine("Usage: InjectorStandalone <PID> <dllPath>");
+                System.Environment.Exit(1);
+            }
+
+            int pid = int.Parse(args[0]);
+            string dllPath = args[1];
+
+            TribesLauncherSharp.InjectorLauncher.Inject(pid, dllPath);
+        }
+    }
+}

--- a/InjectorStandalone/InjectorStandalone.csproj
+++ b/InjectorStandalone/InjectorStandalone.csproj
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{36EB17C1-0055-4154-9C84-836121AE53C9}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>InjectorStandalone</RootNamespace>
+    <AssemblyName>InjectorStandalone</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Management" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\InjectorLauncher.cs">
+      <Link>InjectorLauncher.cs</Link>
+    </Compile>
+    <Compile Include="InjectorStandalone.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/InjectorStandalone/Properties/AssemblyInfo.cs
+++ b/InjectorStandalone/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("InjectorStandalone")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("InjectorStandalone")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("36eb17c1-0055-4154-9c84-836121ae53c9")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/TribesLauncherSharp.sln
+++ b/TribesLauncherSharp.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.168
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31613.86
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TribesLauncherSharp", "TribesLauncherSharp.csproj", "{0B89CF62-820D-40B9-B67F-144BD1C17CB7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InjectorStandalone", "InjectorStandalone\InjectorStandalone.csproj", "{36EB17C1-0055-4154-9C84-836121AE53C9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{0B89CF62-820D-40B9-B67F-144BD1C17CB7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0B89CF62-820D-40B9-B67F-144BD1C17CB7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0B89CF62-820D-40B9-B67F-144BD1C17CB7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{36EB17C1-0055-4154-9C84-836121AE53C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{36EB17C1-0055-4154-9C84-836121AE53C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{36EB17C1-0055-4154-9C84-836121AE53C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{36EB17C1-0055-4154-9C84-836121AE53C9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Creates a new InjectorStandalone.exe executable, which takes only a PID and a dllPath and injects the dll to that PID. This is useful for running TribesAscend.exe with TAMods in linux using wine. It is mainly for the server, where using a separate exe to inject the dll instead of doing it in taserver's python will let us run python natively instead of in wine and simplify a lot of other setup & code. 

Testing
- Have been using this to inject TAMods-server on my active taserver instances for several weeks without any issues
- Verified that this can also be used to inject TAMods on the game client